### PR TITLE
Differentiate private and public key sizes

### DIFF
--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -101,7 +101,7 @@ enum {
     hash_alg = PSA_ALG_SHA_256,
     alg = PSA_ALG_ECDSA(hash_alg),
     sig_size = PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE(key_type, priv_bits, alg),
-    pubkey_size = PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(pub_bits),
+    pubkey_size = PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(priv_bits),
     hash_size = PSA_HASH_SIZE(hash_alg),
 };
 

--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -96,11 +96,12 @@ psa_key_slot_number_t atecc608a_public_key_slot = 9;
 enum {
     key_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1),
     keypair_type = PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1),
-    key_bits = 256,
+    priv_bits = PSA_BYTES_TO_BITS(32),
+    pub_bits = PSA_BYTES_TO_BITS(64),
     hash_alg = PSA_ALG_SHA_256,
     alg = PSA_ALG_ECDSA(hash_alg),
-    sig_size = PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE(key_type, key_bits, alg),
-    pubkey_size = PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(key_bits),
+    sig_size = PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE(key_type, priv_bits, alg),
+    pubkey_size = PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(pub_bits),
     hash_size = PSA_HASH_SIZE(hash_alg),
 };
 
@@ -348,13 +349,14 @@ void setup_key_attributes(psa_key_attributes_t *attributes,
     psa_set_key_id(attributes, slot);
     psa_set_key_lifetime(attributes, PSA_ATECC608A_LIFETIME);
     psa_set_key_algorithm(attributes, alg);
-    psa_set_key_bits(attributes, key_bits);
 
     if (is_private) {
+        psa_set_key_bits(attributes, priv_bits);
         psa_set_key_usage_flags(attributes, PSA_KEY_USAGE_SIGN);
         psa_set_key_type(attributes,
                          PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1));
     } else {
+        psa_set_key_bits(attributes, pub_bits);
         psa_set_key_usage_flags(attributes, PSA_KEY_USAGE_VERIFY);
         psa_set_key_type(attributes,
                          PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1));

--- a/atecc608a/main.c
+++ b/atecc608a/main.c
@@ -22,11 +22,11 @@
 
 #if defined(ATCA_HAL_I2C)
 #include "psa/crypto.h"
+#include "psa/lifecycle.h"
 #include "atecc608a_se.h"
 #include "atecc608a_utils.h"
 #include "atca_helpers.h"
 #include "atecc508a_config_dev.h"
-#include "psa_crypto_storage.h"
 /** This macro checks if the result of an `expression` is equal to an
  *  `expected` value and sets a `status` variable of type `psa_status_t` to
  *  `PSA_SUCCESS`. If they are not equal, the `status` is set to
@@ -75,19 +75,6 @@
     "the values in these zones cannot be modified; locking indicates that\n"\
     "the slot now behaves according to the policies set by the associated\n"\
     "configuration zone’s values. [y/n]: "
-
-static void psa_purge_keys(void)
-{
-    psa_key_id_t id;
-    printf("Clearing persistent key data\n");
-    /* Clear slots 0-15 of persistent storage. These numbers are equal to
-     * physical slots available on the device. */
-    for (id = 0; id < 16; id++) {
-        psa_destroy_persistent_key(id);
-    }
-    /* Purge the transaction file. */
-    psa_crypto_stop_transaction();
-}
 
 /* Data used by tests */
 psa_key_slot_number_t atecc608a_private_key_slot = 1;
@@ -370,7 +357,7 @@ psa_status_t run_tests()
     psa_key_attributes_t private_key_attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_handle_t private_handle;
 
-    psa_purge_keys();
+    mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
 
     setup_key_attributes(&public_key_attributes,
                          atecc608a_public_key_slot, 0);
@@ -391,7 +378,7 @@ psa_status_t run_tests()
 
     /* Purge, so that we can test driver behaviour with a key that is registered,
      * not generated. */
-    psa_purge_keys();
+    mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
     ASSERT_SUCCESS_PSA(mbedtls_psa_register_se_key(&private_key_attributes));
 
     ASSERT_SUCCESS_PSA(test_export_import(&private_handle,
@@ -604,7 +591,7 @@ int main(void)
     bool exit_application = false;
 
     print_device_info();
-    psa_destroy_se_persistent_data(PSA_ATECC608A_LIFETIME);
+    mbed_psa_reboot_and_request_new_security_state(PSA_LIFECYCLE_ASSEMBLY_AND_TEST);
     ASSERT_SUCCESS_PSA(psa_register_se_driver(PSA_ATECC608A_LIFETIME, &atecc608a_drv_info));
 
     ASSERT_SUCCESS_PSA(psa_crypto_init());


### PR DESCRIPTION
Note, this requires a change in mbed-os-atecc608a so that `atecc608a_import_public_key()` returns `64 * 8` instead of `72 * 8`, as 72 bytes represent the internal representation's size rather than the actual key's size.